### PR TITLE
only display label-edit when chart is wrapped in chart-edit-mode clas…

### DIFF
--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -107,6 +107,14 @@ body {
 
 }
 
+.chart-edit-mode {
+    .axis-label-edit {
+        display: flex !important;
+    }
+    .y-axis-label, .x-axis-label {
+        display: none;
+    }
+}
 
 .dc-chart {
     position: relative;
@@ -411,17 +419,18 @@ body {
         bottom: 4px;
     }
 
+
+
     div.axis-label-edit {
         pointer-events: none;
         text-align: center;
-        display: flex;
+        display: none;
         justify-content: center;
         width: 100%;
         .input-wrapper {
             position: relative;
             display: block;
         }
-        
         span {
             white-space: nowrap;
             padding: 0 4px;
@@ -482,10 +491,6 @@ body {
             input {
                 opacity: 1;
             }
-        } 
-
-        & + .x-axis-label {
-            display: none;
         }
 
         &.has-legend {

--- a/src/mixins/label-mixin.js
+++ b/src/mixins/label-mixin.js
@@ -51,7 +51,7 @@ export default function labelMixin (chart) {
   }
 
   function getXaxisLeftPosition (hasLegend) {
-    return hasLegend ? chart.width() / 2 + 32 : chart.effectiveWidth() / 2 + chart.margins().left
+    return hasLegend ? (chart.effectiveWidth() / 2) + 32 : (chart.effectiveWidth() / 2) + chart.margins().left
   }
 
   function getYaxisTopPosition () {
@@ -92,10 +92,6 @@ export default function labelMixin (chart) {
       .selectAll(`.axis-label-edit.type-${type}`)
       .remove()
 
-    chart
-      .root()
-      .selectAll(".y-axis-label, .x-axis-label")
-      .style("display", "none")
 
     const editorWrapper = chart
       .root()


### PR DESCRIPTION
…s and renderLabel enabled

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
