### PR TITLE
Expose mapbox access token to map-mixin as .mapbboxToken

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -9470,7 +9470,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  var _mapboxgl = typeof _mapboxgl === "undefined" ? mapboxgl : _mapboxgl;
 	  var _map = null;
-	  var _mapboxAccessToken = "pk.eyJ1IjoibWFwZCIsImEiOiJjaWV1a3NqanYwajVsbmdtMDZzc2pneDVpIn0.cJnk8c2AxdNiRNZWtx5A9g";
+	  var _mapboxAccessToken = null;
 	  var _lastWidth = null;
 	  var _lastHeight = null;
 	  var _mapId = chartDivId;
@@ -9731,6 +9731,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	      }
 	    }
 
+	    return _chart;
+	  };
+
+	  _chart.mapboxToken = function (mapboxToken) {
+	    if (!arguments.length) {
+	      return _mapboxAccessToken;
+	    }
+	    _mapboxAccessToken = mapboxToken;
 	    return _chart;
 	  };
 

--- a/example/exampleMultiLayerMap.js
+++ b/example/exampleMultiLayerMap.js
@@ -53,6 +53,7 @@ document.addEventListener("DOMContentLoaded", function init() {
   function createPointMap(polycfLayer1, pointcfLayer2, pointcfLayer3, con) {
     var w = document.documentElement.clientWidth - 30;
     var h = Math.max(document.documentElement.clientHeight, window.innerHeight || 0) - 150;
+    var mapboxToken = "pk.eyJ1IjoibWFwZCIsImEiOiJjaWV1a3NqanYwajVsbmdtMDZzc2pneDVpIn0.cJnk8c2AxdNiRNZWtx5A9g";
 
     /*---------------------BASIC COUNT ON CROSSFILTER--------------------------*/
     /*
@@ -98,7 +99,7 @@ document.addEventListener("DOMContentLoaded", function init() {
     var polyLayer1 = dc.rasterLayer("polys")
                        .dimension(polyDim1)
                        .group(polyGrp1)
-                       // .cap(100)  // We can add a cap if we want.
+                       .cap(100)  // Cap is required
                        .fillColorScale(polyFillColorScale)  // set the fill color scale
                        .fillColorAttr('avgContrib')   // set the driving attribute for the fill color scale, in
                                                       // this case, the average contribution
@@ -245,6 +246,7 @@ document.addEventListener("DOMContentLoaded", function init() {
                           .width(w)
                           .mapUpdateInterval(750)
                           .mapStyle('mapbox://styles/mapbox/light-v8')
+                          .mapboxToken(mapboxToken) // need a mapbox accessToken for loading the tiles
 
                           // add the layers to the pointmap
                           .pushLayer('polytable1', polyLayer1)

--- a/src/mixins/map-mixin.js
+++ b/src/mixins/map-mixin.js
@@ -17,7 +17,7 @@ export default function mapMixin (_chart, chartDivId, _mapboxgl, mixinDraw = tru
 
   var _mapboxgl = typeof _mapboxgl === "undefined" ? mapboxgl : _mapboxgl
   let _map = null
-  const _mapboxAccessToken = "pk.eyJ1IjoibWFwZCIsImEiOiJjaWV1a3NqanYwajVsbmdtMDZzc2pneDVpIn0.cJnk8c2AxdNiRNZWtx5A9g"
+  let _mapboxAccessToken = null
   let _lastWidth = null
   let _lastHeight = null
   const _mapId = chartDivId
@@ -273,6 +273,14 @@ export default function mapMixin (_chart, chartDivId, _mapboxgl, mixinDraw = tru
       if (typeof _chart.resetLayer !== "undefined") { _chart.resetLayer() }
     }
 
+    return _chart
+  }
+
+  _chart.mapboxToken = function (mapboxToken) {
+    if (!arguments.length) {
+      return _mapboxAccessToken
+    }
+    _mapboxAccessToken = mapboxToken
     return _chart
   }
 


### PR DESCRIPTION
Expose mapbox access token to map-mixin as .mapbboxToken. Also recompiled mapdc.js.
Works mapd-immerse PR mapd/mapd-immerse/pull/3086

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Author referenced issue(s) fixed by this PR:
- [x] Fixes mapd/mapd-immerse/issues/2947

## :smoking: Smoke Test
- [x] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [x] author crafted PR's title into release-worthy commit message.

## test steps
* open exampleMultiLayerMap.html in browser
* edit exampleMultiLayerMap.js mapboxToken
* verify in Chrome dev tools Network that the right token is used
