### PR TITLE
raster draw: set filterBounds on pointmap when calling filterAll to p…

### DIFF
--- a/src/mixins/raster-draw-mixin.js
+++ b/src/mixins/raster-draw-mixin.js
@@ -345,6 +345,10 @@ export function rasterDrawMixin (chart) {
       shapes.forEach(shape => {
         chart.deleteFilterShape(shape)
       })
+
+      if (typeof chart.useLonLat === "function") { // pointmap should preserve the zoom filter
+        chart.setFilterBounds(chart.map().getBounds())
+      }
       return chart
     }
 


### PR DESCRIPTION
…reserve pointmap zoom filter

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes https://github.com/mapd/mapd-immerse/issues/3114

## :smoking: Smoke Test
- [ ] Works in chrome

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
