### PR TITLE
reset groupAll when reseting state + multi-series fixes

### DIFF
--- a/src/core/core-async.js
+++ b/src/core/core-async.js
@@ -11,8 +11,8 @@ let _redrawStackEmpty = true
 let _startRenderTime = null
 let _startRedrawTime = null
 
-const _groupAll = {}
-const _lastFilteredSize = {}
+let _groupAll = {}
+let _lastFilteredSize = {}
 
 export function startRenderTime () {
   return _startRenderTime
@@ -199,6 +199,8 @@ export function lastFilteredSize (crossfilterId) {
 }
 
 export function resetState () {
+  _groupAll = {}
+  _lastFilteredSize = {}
   resetRedrawStack()
   resetRenderStack()
 }

--- a/src/mixins/multi-series-mixin.js
+++ b/src/mixins/multi-series-mixin.js
@@ -53,8 +53,12 @@ function processMultiSeriesResults (results) {
 }
 
 function selectWithCase (dimension, values) {
-  const set = values.map(val => `'${val.replace(/'/, "''")}'`).join(",")
-  return `CASE when ${dimension} IN (${set}) then ${dimension} ELSE 'other' END`
+  if (dimension.slice(0, 9) === "CASE when") {
+    return dimension
+  } else {
+    const set = values.map(val => `'${val.replace(/'/, "''")}'`).join(",")
+    return `CASE when ${dimension} IN (${set}) then ${dimension} ELSE 'other' END`
+  }
 }
 
 function setDimensionsWithColumns (columns, selected) {
@@ -150,12 +154,11 @@ export default function multiSeriesMixin (chart) {
               hasSelected ? currentSelected : chart.series().values().slice(0, TOP)
             )
 
-          if (chart.rangeChart()) {
-            chart
-              .group()
-              .dimension()
-              .set(setDimensionsWithColumns(columns, chart.series().selected()))
-          }
+          chart
+            .group()
+            .dimension()
+            .set(setDimensionsWithColumns(columns, chart.series().selected()))
+
           chart.group().dimension().multiDim(false)
 
           return chart


### PR DESCRIPTION
Two changes:

1. We now reset `groupAll` when resetting state. 

1. we don't re-apply the case statement to the multi-series dimension if its already transformed into a case statement.