### PR TITLE
fixed geochoropleth chart issue

### DIFF
--- a/src/charts/geo-choropleth-chart.js
+++ b/src/charts/geo-choropleth-chart.js
@@ -27,9 +27,9 @@ import {utils} from "../utils/utils"
  */
 export default function geoChoroplethChart (parent, useMap, chartGroup, mapbox) {
   const _useMap = useMap !== undefined ? useMap : false
-  const parentDivId = parent.attributes.id.value
   let _chart = null
   if (_useMap) {
+    const parentDivId = parent.attributes.id.value
     _chart = mapMixin(colorMixin(baseMixin({})), parentDivId, mapbox)
   } else {
     _chart = colorMixin(baseMixin({}))


### PR DESCRIPTION
# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.

There is an issue when using the geoChoroplethChart. If you just supply a normal selector when initiating the chart, there is no `parent.attributes.id.value`. Apparently you only use this when doing stuff with maps, so i moved it into the conditional check.
