### PR TITLE
upgrade legendables for ie numeric input fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "d3": "^3.5.17",
     "deep-equal": "1.0.1",
     "earcut": "^2.1.1",
-    "legendables": "1.0.0-rc.7",
+    "legendables": "1.0.0-rc.8",
     "mapbox-gl": "https://github.com/mapd/mapbox-gl-js/tarball/9c04de6949fe498c8c79f5c0627dfd6d6321f307",
     "mapd-data-layer": "0.0.3-beta",
     "moment": "2.13.0",


### PR DESCRIPTION
# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Author referenced issue(s) fixed by this PR:
- [x] Fixes https://github.com/mapd/mapd-immerse/issues/3515

## :smoking: Smoke Test
- [x] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [x] Works in ie edge
- [x] Works in ie 11

## :ship: Merge
- [x] author crafted PR's title into release-worthy commit message.
