### PR TITLE
use file ext with d3.box for usage with webpack 3.x

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ if (process.env.BABEL_ENV !== "test") {
 }
 
 require("./polyfills/inner-svg")
-require("./mixins/d3.box")
+require("./mixins/d3.box.js")
 
 export * as d3 from "d3" // eslint-disable-line
 export * from "./core/core"


### PR DESCRIPTION
For some reason the line `require("./mixins/d3.box");` is breaking Webpack 3.x in Immerse. Changing this line to include the `.js` file extension seems to fix it, I don't imagine there will be any side effects of doing so.
