### PR TITLE
Reposition legend bottom-left to also fix draw panel #3894

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -44000,7 +44000,6 @@ function lineChart(parent, chartGroup) {
       layersList = chartBody.append("g").attr("class", "stack-list");
     }
 
-    console.log("_chart.data()", _chart.data());
     var layers = layersList.selectAll("g.stack").data(_chart.data());
 
     var layersEnter = layers.enter().append("g").attr("class", function (d, i) {

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -44000,6 +44000,7 @@ function lineChart(parent, chartGroup) {
       layersList = chartBody.append("g").attr("class", "stack-list");
     }
 
+    console.log("_chart.data()", _chart.data());
     var layers = layersList.selectAll("g.stack").data(_chart.data());
 
     var layersEnter = layers.enter().append("g").attr("class", function (d, i) {
@@ -45386,7 +45387,7 @@ function legendState(state) {
       open: hasLegendOpenProp(state) ? state.legend.open : true,
       range: state.range,
       domain: state.domain,
-      position: useMap ? "bottom-left" : "top-right"
+      position: "bottom-left"
     };
   } else if (state.type === "quantitative") {
     return {
@@ -45396,7 +45397,7 @@ function legendState(state) {
       open: hasLegendOpenProp(state) ? state.legend.open : true,
       range: state.range,
       domain: state.domain,
-      position: useMap ? "bottom-left" : "top-right"
+      position: "bottom-left"
     };
   } else if (state.type === "quantize") {
     var scale = state.scale;
@@ -45408,7 +45409,7 @@ function legendState(state) {
       open: hasLegendOpenProp(state) ? state.legend.open : true,
       range: scale.range,
       domain: scale.domain,
-      position: useMap ? "bottom-left" : "top-right"
+      position: "bottom-left"
     };
   } else {
     return {};

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -150,7 +150,7 @@ export function handleLegendInput ({domain, index = 0}) {
   this.renderAsync()
 }
 
-function legendState (state, useMap = true) {
+function legendState (state) {
   if (state.type === "ordinal") {
     return {
       type: "nominal",

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -158,7 +158,7 @@ function legendState (state, useMap = true) {
       open: hasLegendOpenProp(state) ? state.legend.open : true,
       range: state.range,
       domain: state.domain,
-      position: useMap ? "bottom-left" : "top-right"
+      position: "bottom-left"
     }
   } else if (state.type === "quantitative") {
     return {
@@ -168,7 +168,7 @@ function legendState (state, useMap = true) {
       open: hasLegendOpenProp(state) ? state.legend.open : true,
       range: state.range,
       domain: state.domain,
-      position: useMap ? "bottom-left" : "top-right"
+      position: "bottom-left"
     }
   } else if (state.type === "quantize") {
     const {scale} = state
@@ -179,7 +179,7 @@ function legendState (state, useMap = true) {
       open: hasLegendOpenProp(state) ? state.legend.open : true,
       range: scale.range,
       domain: scale.domain,
-      position: useMap ? "bottom-left" : "top-right"
+      position: "bottom-left"
     }
   } else {
     return {}


### PR DESCRIPTION
Fixes unclickable draw tools, restore vertical draw panel, reposition legend bottom-left. All these bugs has as common cause: the legend positioned on top-left.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Author referenced issue(s) fixed by this PR:
- [x] Fixes https://github.com/mapd/mapd-immerse/issues/3894

## :smoking: Smoke Test
- [x] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
