### PR TITLE
keep ordinal legend top-right

### DIFF
--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -150,7 +150,7 @@ export function handleLegendInput ({domain, index = 0}) {
   this.renderAsync()
 }
 
-function legendState (state) {
+function legendState (state, useMap = true) {
   if (state.type === "ordinal") {
     return {
       type: "nominal",
@@ -158,7 +158,7 @@ function legendState (state) {
       open: hasLegendOpenProp(state) ? state.legend.open : true,
       range: state.range,
       domain: state.domain,
-      position: "bottom-left"
+      position: useMap ? "bottom-left" : "top-right"
     }
   } else if (state.type === "quantitative") {
     return {


### PR DESCRIPTION
Restore top-right positioning for ordinal legend

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes https://github.com/mapd/mapd-immerse/issues/3894

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
