### PR TITLE
line/histo tooltip title

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -9287,18 +9287,15 @@ function coordinateGridMixin(_chart) {
 
   _chart.popupTextAccessor = function (arr) {
     return function () {
-      var numberFormatter = _chart.valueFormatter();
       var dateFormatter = _chart.dateFormatter();
       var customFormatter = null;
       var value = arr[0].datum.data.key0;
       if (Array.isArray(value) && value[0]) {
-        value = value[0].value;
+        value = typeof value[0].value !== "undefined" ? value[0].value : value[0];
       }
 
       if (dateFormatter && value instanceof Date) {
         customFormatter = dateFormatter;
-      } else if (numberFormatter) {
-        customFormatter = numberFormatter;
       }
 
       return customFormatter && customFormatter(value) || _utils.utils.formatValue(value);
@@ -21979,6 +21976,7 @@ function format(value, key, numberFormatter, dateFormatter) {
 }
 
 function multipleKeysLabelMixin(_chart) {
+
   function label(d) {
     var numberFormatter = _chart && _chart.valueFormatter();
     var dateFormatter = _chart && _chart.dateFormatter();

--- a/src/mixins/coordinate-grid-mixin.js
+++ b/src/mixins/coordinate-grid-mixin.js
@@ -1517,18 +1517,15 @@ export default function coordinateGridMixin (_chart) {
   }
 
   _chart.popupTextAccessor = arr => () => {
-    const numberFormatter = _chart.valueFormatter()
     const dateFormatter = _chart.dateFormatter()
     let customFormatter = null
     let value = arr[0].datum.data.key0
     if (Array.isArray(value) && value[0]) {
-      value = value[0].value
+      value = typeof value[0].value !== "undefined" ? value[0].value : value[0]
     }
 
     if (dateFormatter && value instanceof Date) {
       customFormatter = dateFormatter
-    } else if (numberFormatter) {
-      customFormatter = numberFormatter
     }
 
     return customFormatter && customFormatter(value) || utils.formatValue(value)


### PR DESCRIPTION
fix line/histo tooltip title that was NaN and was using the wrong formatter. Also, the whole title is emoty when the measure format is empty.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] https://github.com/mapd/mapd-immerse/issues/4396

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.

Bug:
<img width="376" alt="screen shot 2018-04-20 at 1 11 09 pm" src="https://user-images.githubusercontent.com/824534/39064403-640c944e-449c-11e8-95b4-ee2c49ed5c92.png">

<img width="1362" alt="screen shot 2018-04-20 at 1 12 32 pm" src="https://user-images.githubusercontent.com/824534/39064456-9739efb0-449c-11e8-822b-5b74e5bd9c29.png">

