### PR TITLE
Remove check for 'circle' mark type and its replacement with points

### DIFF
--- a/src/mixins/raster-layer-point-mixin.js
+++ b/src/mixins/raster-layer-point-mixin.js
@@ -459,42 +459,28 @@ export default function rasterLayerPointMixin(_layer) {
 
     const marks = [
       {
-        type: markType === "circle" ? "points" : "symbol",
+        type: "symbol",
         from: {
           data: layerName
         },
         properties: Object.assign(
           {},
-          markType === "circle"
-            ? {
-                x: {
-                  scale: "x",
-                  field: "x"
-                },
-                y: {
-                  scale: "y",
-                  field: "y"
-                },
-                fillColor: getColor(state.encoding.color, layerName)
-              }
-            : {
-                xc: {
-                  scale: "x",
-                  field: "x"
-                },
-                yc: {
-                  scale: "y",
-                  field: "y"
-                },
-                fillColor: getColor(state.encoding.color, layerName)
-              },
-          markType === "circle"
-            ? { size }
-            : {
-                shape: markType,
-                width: size,
-                height: size
-              }
+          {
+            xc: {
+              scale: "x",
+              field: "x"
+            },
+            yc: {
+              scale: "y",
+              field: "y"
+            },
+            fillColor: getColor(state.encoding.color, layerName)
+          },
+          {
+            shape: markType,
+            width: size,
+            height: size
+          }
         )
       }
     ]
@@ -597,7 +583,6 @@ export default function rasterLayerPointMixin(_layer) {
     "y",
     "xc",
     "yc",
-    "size",
     "width",
     "height",
     "fillColor"


### PR DESCRIPTION
This change should be invisible to users, but will allow us to fully deprecate the old point marks and always use circle symbols instead (which was the original intent).

It requires mapd-core to be beyond commit aef949dd70d4abac6790ba7adeebfa04404d9ad5

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR: mapd-charting #195
- [ ] Fixes mapd-charting and #195 mapd-immerse #3880

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
