### PR TITLE
Fixing gradient legend style for dark maps

### DIFF
--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -72,8 +72,9 @@ body {
 .basemap-satellite, .basemap-dark, .basemap-odyssey, .basemap-decimal {
     .gradient-legend .block .text  {
         color: #eeeeee;
+        background: rgba(0,0,0,0.1);
     }
-    
+
     .mapboxgl-ctrl-attrib {
         background: rgba(black, .4);
     }

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -72,7 +72,8 @@ body {
 .basemap-satellite, .basemap-dark, .basemap-odyssey, .basemap-decimal {
     .gradient-legend .block .text  {
         color: #eeeeee;
-        background: rgba(0,0,0,0.1);
+        text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+        background: rgba(0,0,0,0);
     }
 
     .mapboxgl-ctrl-attrib {

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -70,6 +70,10 @@ body {
 }
 
 .basemap-satellite, .basemap-dark, .basemap-odyssey, .basemap-decimal {
+    .gradient-legend .block .text  {
+        color: #eeeeee;
+    }
+    
     .mapboxgl-ctrl-attrib {
         background: rgba(black, .4);
     }

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -73,7 +73,7 @@ body {
     .gradient-legend .block .text  {
         color: #eeeeee;
         text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
-        background: rgba(0,0,0,0);
+        background: transparent;
     }
 
     .mapboxgl-ctrl-attrib {


### PR DESCRIPTION
Fixes legend colors for dark maps:
### Before:
<img width="205" alt="screen shot 2018-04-25 at 11 28 18 pm" src="https://user-images.githubusercontent.com/16374964/39289296-617e09fe-48e0-11e8-9cc3-73b09ddac97f.png">

### After: 
<img width="192" alt="screen shot 2018-04-25 at 11 31 55 pm" src="https://user-images.githubusercontent.com/16374964/39289418-e39cab3e-48e0-11e8-83fd-f94dc8281620.png">
