### PR TITLE
column filter on measure will update global filter

### DIFF
--- a/src/charts/mapd-table.js
+++ b/src/charts/mapd-table.js
@@ -361,6 +361,7 @@ export default function mapdTable(parent, chartGroup) {
             clearColFilter(col.expression)
           } else {
             filterCol(col.expression, d[col.name])
+            _chart.onClick(d[col.name]) // will update global filter Clear icon
           }
         })
     })

--- a/src/charts/mapd-table.js
+++ b/src/charts/mapd-table.js
@@ -522,6 +522,7 @@ export default function mapdTable(parent, chartGroup) {
     delete _columnFilterMap[expr]
     _chart.removeFilteredColumn(expr)
     _tableFilter.filter(computeTableFilter(_columnFilterMap))
+    _chart.filterAll()
     redrawAllAsync(_chart.chartGroup())
   }
 

--- a/src/mixins/base-mixin.js
+++ b/src/mixins/base-mixin.js
@@ -1366,7 +1366,7 @@ export default function baseMixin(_chart) {
    * @param {*} datum
    */
   _chart.onClick = function(datum) {
-    // filtering on dimension will have key, but for filtering on measures which is on column is the column value only
+    // filtering on dimension will have key, but for filtering on measures which is on column doesn't. Thus, the filter is the column value only
     const filter = _chart.keyAccessor()(datum).length > 0 ? _chart.keyAccessor()(datum) : datum
     _chart.handleFilterClick(d3.event, filter)
   }
@@ -1884,6 +1884,11 @@ export default function baseMixin(_chart) {
     }
     _dateFormatter = formatter
     return _chart
+  }
+
+  _chart.getMeasureName = function() {
+    const measure = _chart.group().reduce()
+    return (measure && measure[0]) ? measure[0].measureName : null
   }
 
   _chart = chartLegendMixin(

--- a/src/mixins/base-mixin.js
+++ b/src/mixins/base-mixin.js
@@ -1367,7 +1367,10 @@ export default function baseMixin(_chart) {
    */
   _chart.onClick = function(datum) {
     // filtering on dimension will have key, but for filtering on measures which is on column doesn't. Thus, the filter is the column value only
-    const filter = _chart.keyAccessor()(datum).length > 0 ? _chart.keyAccessor()(datum) : datum
+    const filter =
+      _chart.keyAccessor()(datum).length > 0
+        ? _chart.keyAccessor()(datum)
+        : datum
     _chart.handleFilterClick(d3.event, filter)
   }
 

--- a/src/mixins/base-mixin.js
+++ b/src/mixins/base-mixin.js
@@ -1366,7 +1366,8 @@ export default function baseMixin(_chart) {
    * @param {*} datum
    */
   _chart.onClick = function(datum) {
-    const filter = _chart.keyAccessor()(datum)
+    // filtering on dimension will have key, but for filtering on measures which is on column is the column value only
+    const filter = _chart.keyAccessor()(datum).length > 0 ? _chart.keyAccessor()(datum) : datum
     _chart.handleFilterClick(d3.event, filter)
   }
 
@@ -1883,11 +1884,6 @@ export default function baseMixin(_chart) {
     }
     _dateFormatter = formatter
     return _chart
-  }
-
-  _chart.getMeasureName = function() {
-    const measure = _chart.group().reduce()
-    return (measure && measure[0]) ? measure[0].measureName : null
   }
 
   _chart = chartLegendMixin(

--- a/src/mixins/filter-mixin.js
+++ b/src/mixins/filter-mixin.js
@@ -34,6 +34,9 @@ export function filterHandlerWithChartContext(_chart) {
 
     if (filters.length === 0) {
       dimension.filterAll(_chart.softFilterClear())
+      if(_chart.clearTableFilter){
+        _chart.clearTableFilter() // global filter also will clear all the columns filters on the table
+      }
     } else if (_chart.hasOwnProperty("rangeFocused")) {
       dimension.filterMulti(
         filters,
@@ -41,6 +44,8 @@ export function filterHandlerWithChartContext(_chart) {
         _chart.filtersInverse(),
         _chart.group().binParams()
       )
+    } else if(_chart.getFilteredColumns && Object.keys(_chart.getFilteredColumns()).length>0){ // case for column filtering on measures
+      return filters
     } else {
       dimension.filterMulti(
         filters,

--- a/src/mixins/filter-mixin.js
+++ b/src/mixins/filter-mixin.js
@@ -34,7 +34,7 @@ export function filterHandlerWithChartContext(_chart) {
 
     if (filters.length === 0) {
       dimension.filterAll(_chart.softFilterClear())
-      if(_chart.clearTableFilter){
+      if (_chart.clearTableFilter) {
         _chart.clearTableFilter() // global filter also will clear all the columns filters on the table
       }
     } else if (_chart.hasOwnProperty("rangeFocused")) {
@@ -44,7 +44,11 @@ export function filterHandlerWithChartContext(_chart) {
         _chart.filtersInverse(),
         _chart.group().binParams()
       )
-    } else if(_chart.getFilteredColumns && Object.keys(_chart.getFilteredColumns()).length>0){ // case for column filtering on measures
+    } else if (
+      _chart.getFilteredColumns &&
+      Object.keys(_chart.getFilteredColumns()).length > 0
+    ) {
+      // case for column filtering on measures
       return filters
     } else {
       dimension.filterMulti(


### PR DESCRIPTION
Description: previously the measure filter on column is only applied in the table chart not the global filter in dashboard level. Contrastingly, only dimension filter in table chart was modifying the global filter. However, the measure filter on column values were crossfiltering across other charts, so it was a confusing UX for the users if they are not sure dimension filter (grouped) is filtering differently than the measure filter. Thus, this change will apply the measure filter on column to the global filter as same as dimension filter. 
Check the build on https://github.com/mapd/mapd-immerse/pull/4484
Please check the description on the related immerse  PR to reproduce the reported issue.
# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
