### PR TITLE
fixed date format not formatting other time units besides TIMESTAMP

### DIFF
--- a/src/charts/mapd-table.js
+++ b/src/charts/mapd-table.js
@@ -250,7 +250,7 @@ export default function mapdTable(parent, chartGroup) {
     if (_isGroupedData) {
       _chart
         .dimension()
-        .value()
+        .getDimensionName()
         .forEach((d, i) => {
           cols.push({
             expression: d,

--- a/src/mixins/multiple-key-label-mixin.js
+++ b/src/mixins/multiple-key-label-mixin.js
@@ -32,7 +32,7 @@ export default function multipleKeysLabelMixin(_chart) {
   function label(d) {
     const numberFormatter = _chart && _chart.valueFormatter()
     const dateFormatter = _chart && _chart.dateFormatter()
-    const dimensionNames = _chart.dimension().value()
+    const dimensionNames = _chart.dimension().getDimensionName()
 
     if (dimensionNames.length === 1) {
       return format(d.key0, dimensionNames[0], numberFormatter, dateFormatter)


### PR DESCRIPTION
Related with https://github.com/mapd/mapd-crossfilter/pull/56
# Merge Checklist
## :wrench: Issue(s) fixed:


- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #https://github.com/mapd/mapd-immerse/issues/4521

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
