### PR TITLE
Better font calculation

### DIFF
--- a/src/charts/number-chart.js
+++ b/src/charts/number-chart.js
@@ -73,7 +73,7 @@ export default function numberChart(parent, chartGroup) {
     const TEXT_MARGINS = 64
     const chartWidth = _chart.width() - TEXT_MARGINS
     const chartHeight = _chart.height() - TEXT_MARGINS
-    const fontSize = utils.getFontSizeFromWidth(formattedValue, wrapper, chartWidth, chartHeight)
+    const fontSize = utils.getFontSizeFromWidth(formattedValue, chartWidth, chartHeight)
     wrapper
       .append("span")
       .attr("class", "number-chart-number")

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -388,12 +388,15 @@ utils.b64toBlob = function(b64Data, contentType, sliceSize) {
   return blob
 }
 
-utils.getFontSizeFromWidth = function(text, parent, chartWidth, chartHeight) {
+utils.getFontSizeFromWidth = function(text, chartWidth, chartHeight) {
   const BASE_FONT_SIZE = 12
   const MIN_FONT_SIZE = 4
-  const tmpText = parent.append("span")
+  const tmpText = d3.select("body").append("span")
+    .attr("class", "tmp-text")
     .style("font-size", BASE_FONT_SIZE + "px")
     .style("position", "absolute")
+    .style("opacity", 0)
+    .style("margin-right", 10000)
     .html(text)
   const node = tmpText.node()
 


### PR DESCRIPTION
The way we calculate the font-size is that we add it to the DOM to compute its size, then we can calculate its font size value. But the temporary span that it was in was inside the number chart panel, which gets `display:none` when another chart is opened in the chart editor, which disables `getBoundingClientRect` calculation. So the fix was to add the temporary div outside of the potentially hidden parent.

Can be tested here: https://github.com/mapd/mapd-immerse/pull/4529

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] https://github.com/mapd/mapd-immerse/issues/4500

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
