### PR TITLE
Uyanga/4502 ie chart label

### DIFF
--- a/src/charts/pie-chart.js
+++ b/src/charts/pie-chart.js
@@ -211,8 +211,8 @@ export default function pieChart(parent, chartGroup) {
         "deselected-label",
         d => _chart.hasFilter() && !isSelectedSlice(d)
       )
-      .html((d) => _chart.label()(d.data))
-      .html(function(d) {
+      .text((d) => _chart.label()(d.data))
+      .text(function(d) {
         const availableLabelWidth = getAvailableLabelWidth(d)
         const width = d3
           .select(this)

--- a/src/charts/row-chart.js
+++ b/src/charts/row-chart.js
@@ -429,7 +429,7 @@ export default function rowChart(parent, chartGroup) {
           d => _chart.hasFilter() && !isSelectedRow(d)
         )
         /* --------------------------------------------------------------------------*/
-        .html(_chart.label())
+        .text(_chart.label())
       transition(lab, _chart.transitionDuration()).attr("transform", translateX)
     }
 
@@ -445,7 +445,7 @@ export default function rowChart(parent, chartGroup) {
         .attr("dy", isStackLabel() ? "1.1em" : _dyOffset)
         .on("click", onClick)
         .attr("text-anchor", isStackLabel() ? "start" : "end")
-        .html(d => {
+        .text(d => {
           if (d.label) {
             return d.label
           } else {

--- a/src/mixins/bubble-mixin.js
+++ b/src/mixins/bubble-mixin.js
@@ -153,7 +153,7 @@ export default function bubbleMixin(_chart) {
       label
         .attr("opacity", 0)
         .attr("pointer-events", labelPointerEvent)
-        .html(labelFunction)
+        .text(labelFunction)
 
       transition(label, _chart.transitionDuration()).attr("opacity", 1)
 


### PR DESCRIPTION
Description: Bar/row, Pie, and Bubble charts labels were not visible on IE.
# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #https://github.com/mapd/mapd-immerse/issues/4502

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
