### PR TITLE
Chrisv/ie label

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -4931,10 +4931,10 @@ utils.b64toBlob = function (b64Data, contentType, sliceSize) {
   return blob;
 };
 
-utils.getFontSizeFromWidth = function (text, parent, chartWidth, chartHeight) {
+utils.getFontSizeFromWidth = function (text, chartWidth, chartHeight) {
   var BASE_FONT_SIZE = 12;
   var MIN_FONT_SIZE = 4;
-  var tmpText = parent.append("span").style("font-size", BASE_FONT_SIZE + "px").style("position", "absolute").html(text);
+  var tmpText = _d2.default.select("body").append("span").attr("class", "tmp-text").style("font-size", BASE_FONT_SIZE + "px").style("position", "absolute").style("opacity", 0).style("margin-right", 10000).html(text);
   var node = tmpText.node();
 
   var textWidth = null;
@@ -10334,7 +10334,7 @@ function bubbleMixin(_chart) {
         label = bubbleGEnter.append("text").attr("text-anchor", "middle").attr("dy", ".3em").on("click", _chart.onClick);
       }
 
-      label.attr("opacity", 0).attr("pointer-events", labelPointerEvent).text(labelFunction);
+      label.attr("opacity", 0).attr("pointer-events", labelPointerEvent).html(labelFunction);
 
       (0, _core.transition)(label, _chart.transitionDuration()).attr("opacity", 1);
 
@@ -22075,7 +22075,7 @@ function multipleKeysLabelMixin(_chart) {
   function label(d) {
     var numberFormatter = _chart && _chart.valueFormatter();
     var dateFormatter = _chart && _chart.dateFormatter();
-    var dimensionNames = _chart.dimension().value();
+    var dimensionNames = _chart.dimension().getDimensionName();
 
     if (dimensionNames.length === 1) {
       return format(d.key0, dimensionNames[0], numberFormatter, dateFormatter);
@@ -27714,6 +27714,7 @@ if (Object({"NODE_ENV":"production"}).BABEL_ENV !== "test") {
 }
 
 __webpack_require__(249);
+__webpack_require__(250);
 
 exports.d3 = _d; // eslint-disable-line
 
@@ -46109,9 +46110,9 @@ function pieChart(parent, chartGroup) {
 
     labelsEnter.select(".value-dim").classed("deselected-label", function (d) {
       return _chart.hasFilter() && !isSelectedSlice(d);
-    }).text(function (d) {
+    }).html(function (d) {
       return _chart.label()(d.data);
-    }).text(function (d) {
+    }).html(function (d) {
       var availableLabelWidth = getAvailableLabelWidth(d);
       var width = _d2.default.select(this).node().getBoundingClientRect().width;
       var label = _chart.label()(d.data);
@@ -47390,7 +47391,7 @@ function numberChart(parent, chartGroup) {
     var TEXT_MARGINS = 64;
     var chartWidth = _chart.width() - TEXT_MARGINS;
     var chartHeight = _chart.height() - TEXT_MARGINS;
-    var fontSize = _utils.utils.getFontSizeFromWidth(formattedValue, wrapper, chartWidth, chartHeight);
+    var fontSize = _utils.utils.getFontSizeFromWidth(formattedValue, chartWidth, chartHeight);
     wrapper.append("span").attr("class", "number-chart-number").style("color", _chart.getColor).style("font-size", fontSize + "px").html(formattedValue);
 
     return _chart;
@@ -50890,6 +50891,8 @@ function rowChart(parent, chartGroup) {
       var extent = _d2.default.extent(_rowData, _chart.cappedValueAccessor);
       if (extent[0] > 0) {
         extent[0] = 0;
+      } else if (extent[0] === extent[1] && extent[0] < 0) {
+        extent[1] = 0;
       }
       _x.domain(extent);
     }
@@ -51139,7 +51142,7 @@ function rowChart(parent, chartGroup) {
         return _chart.hasFilter() && !isSelectedRow(d);
       })
       /* --------------------------------------------------------------------------*/
-      .text(_chart.label());
+      .html(_chart.label());
       (0, _core.transition)(lab, _chart.transitionDuration()).attr("transform", translateX);
     }
 
@@ -51147,7 +51150,7 @@ function rowChart(parent, chartGroup) {
     if (_chart.measureLabelsOn()) {
       var measureLab = rows.select(".value-measure").classed("deselected-label", function (d) {
         return _chart.hasFilter() && !isSelectedRow(d);
-      }).attr("y", _labelOffsetY).attr("dy", isStackLabel() ? "1.1em" : _dyOffset).on("click", onClick).attr("text-anchor", isStackLabel() ? "start" : "end").text(function (d) {
+      }).attr("y", _labelOffsetY).attr("dy", isStackLabel() ? "1.1em" : _dyOffset).on("click", onClick).attr("text-anchor", isStackLabel() ? "start" : "end").html(function (d) {
         if (d.label) {
           return d.label;
         } else {
@@ -51966,7 +51969,7 @@ function mapdTable(parent, chartGroup) {
     var cols = [];
 
     if (_isGroupedData) {
-      _chart.dimension().value().forEach(function (d, i) {
+      _chart.dimension().getDimensionName().forEach(function (d, i) {
         cols.push({
           expression: d,
           name: "key" + i,
@@ -55596,6 +55599,104 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
   function boxQuartiles(d) {
     return [_d2.default.quantile(d, 0.25), _d2.default.quantile(d, 0.5), _d2.default.quantile(d, 0.75)];
+  }
+})();
+
+/***/ }),
+/* 250 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+(function () {
+  /* istanbul ignore next */
+  if (window.SVGElement) {
+    var serializeXML = function serializeXML(node, output) {
+      var nodeType = node.nodeType;
+      if (nodeType == 3) {
+        // TEXT nodes.
+        // Replace special XML characters with their entities.
+        output.push(node.textContent.replace(/&/, "&amp;").replace(/</, "&lt;").replace(">", "&gt;"));
+      } else if (nodeType == 1) {
+        // ELEMENT nodes.
+        // Serialize Element nodes.
+        output.push("<", node.tagName);
+        if (node.hasAttributes()) {
+          var attrMap = node.attributes;
+          for (var i = 0, len = attrMap.length; i < len; ++i) {
+            var attrNode = attrMap.item(i);
+            output.push(" ", attrNode.name, "='", attrNode.value, "'");
+          }
+        }
+        if (node.hasChildNodes()) {
+          output.push(">");
+          var childNodes = node.childNodes;
+          for (var i = 0, len = childNodes.length; i < len; ++i) {
+            serializeXML(childNodes.item(i), output);
+          }
+          output.push("</", node.tagName, ">");
+        } else {
+          output.push("/>");
+        }
+      } else if (nodeType == 8) {
+        // TODO(codedread): Replace special characters with XML entities?
+        output.push("<!--", node.nodeValue, "-->");
+      } else {
+        // TODO: Handle CDATA nodes.
+        // TODO: Handle ENTITY nodes.
+        // TODO: Handle DOCUMENT nodes.
+        throw "Error serializing XML. Unhandled node of type: " + nodeType;
+      }
+    };
+    // The innerHTML DOM property for SVGElement.
+    Object.defineProperty(window.SVGElement.prototype, "innerHTML", {
+      get: function get() {
+        var output = [];
+        var childNode = this.firstChild;
+        while (childNode) {
+          serializeXML(childNode, output);
+          childNode = childNode.nextSibling;
+        }
+        return output.join("");
+      },
+      set: function set(markupText) {
+        // Wipe out the current contents of the element.
+        while (this.firstChild) {
+          this.removeChild(this.firstChild);
+        }
+
+        try {
+          // Parse the markup into valid nodes.
+          // var dXML = new DOMParser();
+          // dXML.async = false;
+          // Wrap the markup into a SVG node to ensure parsing works.
+          markupText = "<svg xmlns='http://www.w3.org/2000/svg'>" + markupText + "</svg>";
+
+          var divContainer = document.createElement("div");
+          divContainer.innerHTML = markupText;
+          var svgDocElement = divContainer.querySelector("svg");
+          // Now take each node, import it and append to this element.
+          var childNode = svgDocElement.firstChild;
+          while (childNode) {
+            this.appendChild(this.ownerDocument.importNode(childNode, true));
+            childNode = childNode.nextSibling;
+          }
+        } catch (e) {
+          throw e;
+        }
+      }
+    });
+
+    // The innerSVG DOM property for SVGElement.
+    Object.defineProperty(window.SVGElement.prototype, "innerSVG", {
+      get: function get() {
+        return this.innerHTML;
+      },
+      set: function set(markupText) {
+        this.innerHTML = markupText;
+      }
+    });
   }
 })();
 

--- a/src/charts/pie-chart.js
+++ b/src/charts/pie-chart.js
@@ -211,8 +211,8 @@ export default function pieChart(parent, chartGroup) {
         "deselected-label",
         d => _chart.hasFilter() && !isSelectedSlice(d)
       )
-      .text((d) => _chart.label()(d.data))
-      .text(function(d) {
+      .html((d) => _chart.label()(d.data))
+      .html(function(d) {
         const availableLabelWidth = getAvailableLabelWidth(d)
         const width = d3
           .select(this)

--- a/src/charts/row-chart.js
+++ b/src/charts/row-chart.js
@@ -431,7 +431,7 @@ export default function rowChart(parent, chartGroup) {
           d => _chart.hasFilter() && !isSelectedRow(d)
         )
         /* --------------------------------------------------------------------------*/
-        .text(_chart.label())
+        .html(_chart.label())
       transition(lab, _chart.transitionDuration()).attr("transform", translateX)
     }
 
@@ -447,7 +447,7 @@ export default function rowChart(parent, chartGroup) {
         .attr("dy", isStackLabel() ? "1.1em" : _dyOffset)
         .on("click", onClick)
         .attr("text-anchor", isStackLabel() ? "start" : "end")
-        .text(d => {
+        .html(d => {
           if (d.label) {
             return d.label
           } else {

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ if (process.env.BABEL_ENV !== "test") {
 }
 
 require("./mixins/d3.box.js")
+require("./polyfills/inner-svg")
 
 export * as d3 from "d3" // eslint-disable-line
 export * from "./core/core"

--- a/src/mixins/bubble-mixin.js
+++ b/src/mixins/bubble-mixin.js
@@ -153,7 +153,7 @@ export default function bubbleMixin(_chart) {
       label
         .attr("opacity", 0)
         .attr("pointer-events", labelPointerEvent)
-        .text(labelFunction)
+        .html(labelFunction)
 
       transition(label, _chart.transitionDuration()).attr("opacity", 1)
 


### PR DESCRIPTION
Reverts the fix https://github.com/mapd/mapd-charting/pull/219
Re-enable the `inner-svg` polyfill, which was removed here when it was causing compile problems after upgrading jsdom, thinking that it was not used https://github.com/mapd/mapd-charting/pull/181/files#diff-1fdf421c05c1140f6d71444ea2b27638L11

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] https://github.com/mapd/mapd-immerse/issues/4502

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
