### PR TITLE
format cache module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ web/docs/public
 
 # example libs
 example/js
+example/assets
 example/css/mapbox-gl-draw.css
 example/css/mapdc.min.css
 example/css/chart.min.css

--- a/src/charts/row-chart.js
+++ b/src/charts/row-chart.js
@@ -6,6 +6,8 @@ import lockAxisMixin from "../mixins/lock-axis-mixin"
 import marginMixin from "../mixins/margin-mixin"
 import { transition } from "../core/core"
 import { utils } from "../utils/utils"
+import { formatCache } from "../utils/formatting-helpers"
+
 /**
  * Concrete row chart implementation.
  *
@@ -63,6 +65,7 @@ export default function rowChart(parent, chartGroup) {
   let _elasticX
 
   const _xAxis = d3.svg.axis().orient("bottom")
+  const xFormatCache = formatCache(_xAxis)
 
   let _rowData
 
@@ -130,9 +133,9 @@ export default function rowChart(parent, chartGroup) {
     const numberFormatter = _chart.valueFormatter()
     if (numberFormatter) {
       const key = _chart.getMeasureName()
-      _xAxis.tickFormat(d => numberFormatter(d, key))
+      xFormatCache.setTickFormat(d => numberFormatter(d, key))
     } else {
-      _xAxis.tickFormat(null)
+      xFormatCache.setTickFormatFromCache()
     }
   }
 

--- a/src/utils/formatting-helpers.js
+++ b/src/utils/formatting-helpers.js
@@ -128,3 +128,34 @@ export function normalizeFiltersArray(filters) {
     }
   })
 }
+
+export function formatCache(_axis) {
+  const axis = _axis
+  let cachedTickFormat = false
+
+  function setTickFormat (tickFormat, fromCache) {
+    if (tickFormat === false) {
+      return null
+    }
+
+    if (!fromCache && cachedTickFormat === false) {
+      cachedTickFormat = axis.tickFormat()
+    }
+ 
+    axis.tickFormat(tickFormat)
+ 
+    if (fromCache) {
+      cachedTickFormat = false
+    }
+  }
+
+  function setTickFormatFromCache () {
+    const FROM_CACHE = true
+    setTickFormat(cachedTickFormat, FROM_CACHE)
+  }
+
+  return {
+    setTickFormat,
+    setTickFormatFromCache
+  }
+}

--- a/src/utils/formatting-helpers.unit.spec.js
+++ b/src/utils/formatting-helpers.unit.spec.js
@@ -241,4 +241,30 @@ describe("Formatting Helpers", () => {
       expect(Helpers.formatArrayValue(data)).to.equal("2.33 – 10.25")
     })
   })
+
+  describe("format cache helper", () => {
+    const AxisMock = function () {
+      let cachedFormat = d => d + "foo"
+      return {
+        tickFormat: d => {
+          if (!d) {
+            return cachedFormat
+          }
+          cachedFormat = d
+        }
+      }
+    }
+
+    const axisMock = AxisMock()
+    const formatCache = Helpers.formatCache(axisMock)
+
+    it("should cache the format", () => {
+      expect(axisMock.tickFormat()("a")).to.equal("afoo")
+      formatCache.setTickFormat(d => d + "bar")
+      expect(axisMock.tickFormat()("a")).to.equal("abar")
+      formatCache.setTickFormatFromCache()
+      expect(axisMock.tickFormat()("a")).to.equal("afoo")
+    })
+
+  })
 })


### PR DESCRIPTION
Fixes https://github.com/mapd/mapd-immerse/issues/4765 by caching the format that is passed using mapdc API. Same fix as #198 but wrapped in a module (which could be used to polish #198)