### PR TITLE
[FE-8695] - trying a shouldRedrawAll flag

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -34540,6 +34540,7 @@ function mapMixin(_chart, chartDivId, _mapboxgl) {
 
   var _minMaxCache = {};
   var _interactionsEnabled = true;
+  var _shouldRedrawAll = false;
 
   _chart.useLonLat = function (useLonLat) {
     if (!arguments.length) {
@@ -34570,6 +34571,10 @@ function mapMixin(_chart, chartDivId, _mapboxgl) {
 
   _chart.setInitialBounds = function (newBounds) {
     _initialBounds = newBounds;
+  };
+
+  _chart.setShouldRedrawAll = function (newShouldRedrawAll) {
+    _shouldRedrawAll = newShouldRedrawAll;
   };
 
   function makeBoundsArrSafe(_ref) {
@@ -34786,7 +34791,7 @@ function mapMixin(_chart, chartDivId, _mapboxgl) {
     }
     _lastMapUpdateTime = curTime;
 
-    var redrawall = false;
+    var redrawall = _shouldRedrawAll;
     if (typeof _chart.getLayers === "function") {
       _chart.getLayers().forEach(function (layer) {
         if (typeof layer.xDim === "function" && typeof layer.yDim === "function") {

--- a/src/mixins/map-mixin.js
+++ b/src/mixins/map-mixin.js
@@ -68,6 +68,7 @@ export default function mapMixin(
 
   const _minMaxCache = {}
   let _interactionsEnabled = true
+  let _shouldRedrawAll = false
 
   _chart.useLonLat = function(useLonLat) {
     if (!arguments.length) {
@@ -98,6 +99,10 @@ export default function mapMixin(
 
   _chart.setInitialBounds = function(newBounds) {
     _initialBounds = newBounds
+  }
+
+  _chart.setShouldRedrawAll = function(newShouldRedrawAll) {
+    _shouldRedrawAll = newShouldRedrawAll
   }
 
   function makeBoundsArrSafe([[lowerLon, lowerLat], [upperLon, upperLat]]) {
@@ -352,7 +357,7 @@ export default function mapMixin(
     }
     _lastMapUpdateTime = curTime
 
-    let redrawall = false
+    let redrawall = _shouldRedrawAll
     if (typeof _chart.getLayers === "function") {
       _chart.getLayers().forEach(layer => {
         if (


### PR DESCRIPTION
Bullshit hack. Previously, by default we'd default redrawAll to _false_, and then jump through some hoops to see if we want to redraw the charts in the group.

Now, we _still_ default to false, but also allow Immerse to override the value (`shouldRedrawAll`) and if that's set to true, then we default the `redrawAll` behavior to true (which also means we _always_ redrawAll, since there are no subsequent checks that'd turn it off, only on).

Right now this is only used by the GEOJOIN_BOUNDING_BOXES flag and it also doesn't work the way you think it should. I'll open an Immerse PR shortly.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
